### PR TITLE
Update /soup docs & improve robustness

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 python-telegram-bot==13.4
 beautifulsoup4
+pycurl
+certifi
 

--- a/robot/config/__init__.py
+++ b/robot/config/__init__.py
@@ -46,6 +46,8 @@ except:
 
 REQUEST_TIMER = {"launched": datetime.now()}
 
+SOUP_ENDPOINT = "https://www.epfl.ch/campus/restaurants-shops-hotels/fr/offre-du-jour-de-tous-les-points-de-restauration/"
+
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
 )

--- a/robot/config/soup.sh
+++ b/robot/config/soup.sh
@@ -1,1 +1,0 @@
-curl -k "https://www.epfl.ch/campus/restaurants-shops-hotels/fr/offre-du-jour-de-tous-les-points-de-restauration/" -o robot/config/menu.html

--- a/robot/handlers/soup.py
+++ b/robot/handlers/soup.py
@@ -171,7 +171,7 @@ def soup(update, context):
             markup = menu_buffer.getValue().decode(('iso-8859-1'))
         
         except:
-            logger.error("error when fetching raw menu")
+            logger.error("soup: error on fetching raw menu")
 
             # wait 10 minutes before trying to fetch again
             REQUEST_TIMER[fetch_cache] = now - datetime.timedelta(hours=1) + datetime.timedelta(minutes=10)
@@ -189,8 +189,15 @@ def soup(update, context):
         try:
             parsed_menu = Menu.from_html(markup)
         except:
+            logger.error("soup: error on parsing raw menu")
+
             # wait 10 minutes before trying to fetch and parse again
             REQUEST_TIMER[fetch_cache] = now - datetime.timedelta(hours=1) + datetime.timedelta(minutes=10)
+
+            update.message.reply_text(
+                "Petit problème du côté d'EPFL campus ! La commande sera de nouveau disponible dans quelques minutes.",
+                quote=False
+            )
             return
 
         # the parsed html is cached in the bot's memory

--- a/robot/handlers/soup.py
+++ b/robot/handlers/soup.py
@@ -124,31 +124,55 @@ def soup(update, context):
     As of know, only supports price threshold (/soup 10 returns all meal under 10 chf)
     """
     logger.info(f"user #{update.effective_user.id} required soup ({context.args})")
+
+    # timer entry relevant for caching logic
     now = datetime.now()
+
+    # limit the number of soup request per chat id to one per hour
+    # this is the cache entry to store the chat ids and their request times
+    group_cache = "soup_group"
     
-    if "soup_group" not in REQUEST_TIMER:
-       REQUEST_TIMER["soup_group"] = {}
-    if str(update.message.chat_id) in REQUEST_TIMER["soup_group"] and (now-REQUEST_TIMER["soup_group"][str(update.message.chat_id)][0]).total_seconds() < 3600:
-        context.bot.send_message(
-                chat_id = update.message.chat_id,
-                text = "🙄",
-                reply_to_message_id = REQUEST_TIMER["soup_group"][str(update.message.chat_id)][1],
-                disable_notification = True)
-        return
+    # create the request timer cache entry
+    if group_cache not in REQUEST_TIMER:
+       REQUEST_TIMER[group_cache] = {}
+
+    # the chat id of the current request, this is the id of a timer cache entry
+    group_request = str(update.message.chat_id)
+
+    # the chat id already exists in the timer cache and the current request is too recent
     if (
-        "soup" not in REQUEST_TIMER
-        or (now - REQUEST_TIMER["soup"]).total_seconds() >= 3600
+        group_request in REQUEST_TIMER[group_cache] and
+        (now - REQUEST_TIMER[group_cache][group_request]).total_seconds() < 3600
     ):
-        # Fetches the daily menu
+        logger.info("dropped soup request")
+        return
+
+    # limit the fetch of the menu's data to one per hour
+    # a request still has to trigger the fetch!
+    fetch_cache = "soup_cache"
+
+    # fetch if nothing is currently cached or if the cache expired
+    if (
+        fetch_cache not in REQUEST_TIMER or
+        (now - REQUEST_TIMER[fetch_cache]).total_seconds() >= 3600
+    ):
+
+        # fetch the raw html
         os.system(f"sh {SOUP} {datetime.today().strftime('%Y-%m-%d')}")
-        REQUEST_TIMER["soup"] = now
+
+        # update the most recent fetch's timestamp
+        REQUEST_TIMER[fetch_cache] = now
+
+        # parse the raw html and cache it as the most recent fetch
+        # the parsed html is cached in the bot's memory
         with open(MENU, "r") as markup:
-            context.bot_data["soup_cache"] = Menu.from_html(markup)
+            context.bot_data[fetch_cache] = Menu.from_html(markup)
 
-    menu: Menu = context.bot_data["soup_cache"]
+    # following the code above, the cache entry must exist
+    menu: Menu = context.bot_data[fetch_cache]
+
+    # regular arg parsing
     inputs: List[Any] = context.args
-
-    # arg parsing
     budget = None
     vegetarian = None
     if len(inputs):
@@ -175,9 +199,12 @@ def soup(update, context):
         if len(menu_filter.filters):
             menu = menu_filter(menu)
 
-    soup_id = update.message.reply_text(
+    # send the menu! :)
+    update.message.reply_text(
         str(menu),
         quote=False,
         parse_mode=telegram.constants.PARSEMODE_HTML,
-    ).message_id
-    REQUEST_TIMER["soup_group"][str(update.message.chat_id)] = (now, soup_id)
+    )
+
+    # the group/user has to wait 1h before any further soup request
+    REQUEST_TIMER[group_cache][group_request] = now

--- a/robot/handlers/soup.py
+++ b/robot/handlers/soup.py
@@ -159,7 +159,7 @@ def soup(update, context):
         (now - REQUEST_TIMER[fetch_cache]).total_seconds() >= 3600
     ):
 
-        # fetch the raw html
+        # fetch and parse the raw html
         try:
             menu_buffer = BytesIO()
             c = pycurl.Curl()
@@ -169,26 +169,13 @@ def soup(update, context):
             c.perform()
             c.close()
             markup = menu_buffer.getValue().decode('iso-8859-1')
+
+            parsed_menu = Menu.from_html(markup)
         
         except:
-            logger.error("soup: error on fetching raw menu")
+            logger.error("soup: error on fetching/parsing raw menu")
 
             # wait 10 minutes before trying to fetch again
-            REQUEST_TIMER[fetch_cache] = now - datetime.timedelta(hours=1) + datetime.timedelta(minutes=10)
-
-            update.message.reply_text(
-                "Petit problème du côté d'EPFL campus ! La commande sera de nouveau disponible dans quelques minutes.",
-                quote=False
-            )
-            return
-
-        # parse the raw html
-        try:
-            parsed_menu = Menu.from_html(markup)
-        except:
-            logger.error("soup: error on parsing raw menu")
-
-            # wait 10 minutes before trying to fetch and parse again
             REQUEST_TIMER[fetch_cache] = now - datetime.timedelta(hours=1) + datetime.timedelta(minutes=10)
 
             update.message.reply_text(

--- a/robot/handlers/soup.py
+++ b/robot/handlers/soup.py
@@ -168,7 +168,7 @@ def soup(update, context):
             c.setopt(pycurl.CAINFO, certifi.where())
             c.perform()
             c.close()
-            markup = menu_buffer.getValue().decode(('iso-8859-1'))
+            markup = menu_buffer.getValue().decode('iso-8859-1')
         
         except:
             logger.error("soup: error on fetching raw menu")
@@ -181,9 +181,6 @@ def soup(update, context):
                 quote=False
             )
             return
-
-        # update the most recent fetch's timestamp
-        REQUEST_TIMER[fetch_cache] = now
 
         # parse the raw html
         try:
@@ -199,6 +196,9 @@ def soup(update, context):
                 quote=False
             )
             return
+
+        # update the most recent fetch's timestamp
+        REQUEST_TIMER[fetch_cache] = now
 
         # the parsed html is cached in the bot's memory
         context.bot_data[fetch_cache] = parsed_menu


### PR DESCRIPTION
J'ai ajouté des commentaires à /soup et remplacé le call système à cURL par PycURL :) Comme ça, on utilise une interface Python prévue à cet effet et le bot n'écrit plus l'HTML du menu sur le file system.

Aussi, un groupe/utilisateur envoyant une requête soup, alors qu'il l'a déjà fait dans l'heure, verra sa requête défaussée tôt dans le handler soup : seuls un accès cache et quelques branchings sont effectués. En gros, j'ai enlevé la réponse du bot à son dernier message.

Finalement, si le fetch ou le parsing de l'HTML échoue, alors le bot attendra 10min avant de refetch et reparse.